### PR TITLE
Fix mismatch on datetime string

### DIFF
--- a/eindhoven/models.py
+++ b/eindhoven/models.py
@@ -39,6 +39,6 @@ class ParkingSpot:
             longitude=geo[0],
             latitude=geo[1],
             updated_at=datetime.strptime(
-                data["record_timestamp"], "%Y-%m-%dT%H:%M:%SZ"
+                data["record_timestamp"], "%Y-%m-%dT%H:%M:%S.%fZ"
             ),
         )

--- a/tests/fixtures/charging_parking.json
+++ b/tests/fixtures/charging_parking.json
@@ -38,7 +38,7 @@
                     51.44487067822449
                 ]
             },
-            "record_timestamp": "2022-08-01T21:45:03Z"
+            "record_timestamp": "2022-09-01T21:45:03.599Z"
         }
     ],
     "facet_groups": [

--- a/tests/fixtures/crossed_out_parking.json
+++ b/tests/fixtures/crossed_out_parking.json
@@ -38,7 +38,7 @@
                     51.44925539150587
                 ]
             },
-            "record_timestamp": "2022-08-01T21:45:03Z"
+            "record_timestamp": "2022-09-01T21:45:03.599Z"
         }
     ],
     "facet_groups": [

--- a/tests/fixtures/loading_parking.json
+++ b/tests/fixtures/loading_parking.json
@@ -38,7 +38,7 @@
                     51.441680658515224
                 ]
             },
-            "record_timestamp": "2022-08-01T21:45:03Z"
+            "record_timestamp": "2022-09-01T21:45:03.599Z"
         }
     ],
     "facet_groups": [

--- a/tests/fixtures/parking.json
+++ b/tests/fixtures/parking.json
@@ -2,7 +2,7 @@
     "nhits": 10260,
     "parameters": {
         "dataset": "parkeerplaatsen",
-        "rows": 2,
+        "rows": 1,
         "start": 0,
         "refine": {
             "type_en_merk": "Parkeerplaats"
@@ -13,61 +13,32 @@
     "records": [
         {
             "datasetid": "parkeerplaatsen",
-            "recordid": "7902a02c7e53b590c95563f48af7f8181dad8884",
+            "recordid": "b124abb045f038a12a255e410ccfceb49dba7c77",
             "fields": {
-                "straat": "Veldmaarschalk Montgomerylaan",
+                "straat": "Marconilaan",
                 "type_en_merk": "Parkeerplaats",
                 "geo_point_2d": [
-                    51.445575257690564,
-                    5.470836058595791
+                    51.450176173744275,
+                    5.457883100818987
                 ],
                 "geo_shape": {
                     "coordinates": [
-                        5.470836058595791,
-                        51.445575257690564
+                        5.457883100818987,
+                        51.450176173744275
                     ],
                     "type": "Point"
                 },
                 "aantal": 1.0,
-                "objectid": 101
+                "objectid": 95
             },
             "geometry": {
                 "type": "Point",
                 "coordinates": [
-                    5.470836058595791,
-                    51.445575257690564
+                    5.457883100818987,
+                    51.450176173744275
                 ]
             },
-            "record_timestamp": "2022-08-01T21:45:03Z"
-        },
-        {
-            "datasetid": "parkeerplaatsen",
-            "recordid": "7c1f17204d4c5dfe8ea2d52814765279ed7782b6",
-            "fields": {
-                "straat": "Veldmaarschalk Montgomerylaan",
-                "type_en_merk": "Parkeerplaats",
-                "geo_point_2d": [
-                    51.445463318323576,
-                    5.470953417483847
-                ],
-                "geo_shape": {
-                    "coordinates": [
-                        5.470953417483847,
-                        51.445463318323576
-                    ],
-                    "type": "Point"
-                },
-                "aantal": 1.0,
-                "objectid": 104
-            },
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    5.470953417483847,
-                    51.445463318323576
-                ]
-            },
-            "record_timestamp": "2022-08-01T21:45:03Z"
+            "record_timestamp": "2022-09-01T21:45:03.599Z"
         }
     ],
     "facet_groups": [

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,4 +1,6 @@
 """Test the models."""
+from datetime import datetime
+
 import aiohttp
 import pytest
 from aresponses import ResponsesMockServer
@@ -30,9 +32,23 @@ async def test_parking_model(aresponses: ResponsesMockServer) -> None:
         client = ODPEindhoven(session=session)
         locations: list[ParkingSpot] = await client.locations(parking_type=1, limit=1)
         for item in locations:
-            assert item.spot_id is not None
-            assert item.street is not None
-            assert item.updated_at is not None
+            assert (
+                item.spot_id == "b124abb045f038a12a255e410ccfceb49dba7c77"
+                and isinstance(item.spot_id, str)
+            )
+            assert item.street == "Marconilaan" and isinstance(item.street, str)
+            assert item.parking_type == "Parkeerplaats" and isinstance(
+                item.parking_type, str
+            )
+            assert item.updated_at == datetime(
+                2022, 9, 1, 21, 45, 3, 599000
+            ) and isinstance(item.updated_at, datetime)
+            assert item.longitude == 5.457883100818987 and isinstance(
+                item.longitude, float
+            )
+            assert item.latitude == 51.450176173744275 and isinstance(
+                item.latitude, float
+            )
 
 
 @pytest.mark.asyncio
@@ -96,9 +112,25 @@ async def test_crossed_out_parking_types(aresponses: ResponsesMockServer) -> Non
         client = ODPEindhoven(session=session)
         locations: list[ParkingSpot] = await client.locations(parking_type=4, limit=1)
         for item in locations:
-            assert item.spot_id == "875f9f4cdd316388bfa20e6710aac2d35add2531"
-            assert item.street == "Veldmaarschalk Montgomerylaan"
-            assert item.parking_type == "Parkeerplaats Afgekruist"
+            assert (
+                item.spot_id == "875f9f4cdd316388bfa20e6710aac2d35add2531"
+                and isinstance(item.spot_id, str)
+            )
+            assert item.street == "Veldmaarschalk Montgomerylaan" and isinstance(
+                item.street, str
+            )
+            assert item.parking_type == "Parkeerplaats Afgekruist" and isinstance(
+                item.parking_type, str
+            )
+            assert item.updated_at == datetime(
+                2022, 9, 1, 21, 45, 3, 599000
+            ) and isinstance(item.updated_at, datetime)
+            assert item.longitude == 5.477020648373145 and isinstance(
+                item.longitude, float
+            )
+            assert item.latitude == 51.44925539150587 and isinstance(
+                item.latitude, float
+            )
 
 
 @pytest.mark.asyncio
@@ -118,9 +150,23 @@ async def test_loading_parking_types(aresponses: ResponsesMockServer) -> None:
         client = ODPEindhoven(session=session)
         locations: list[ParkingSpot] = await client.locations(parking_type=5, limit=1)
         for item in locations:
-            assert item.spot_id == "c2f5fee912ee9da593e8224cd6f3cd8a6390dba1"
-            assert item.street == "Stationsweg"
-            assert item.parking_type == "Parkeerplaats laden/lossen"
+            assert (
+                item.spot_id == "c2f5fee912ee9da593e8224cd6f3cd8a6390dba1"
+                and isinstance(item.spot_id, str)
+            )
+            assert item.street == "Stationsweg" and isinstance(item.street, str)
+            assert item.parking_type == "Parkeerplaats laden/lossen" and isinstance(
+                item.parking_type, str
+            )
+            assert item.updated_at == datetime(
+                2022, 9, 1, 21, 45, 3, 599000
+            ) and isinstance(item.updated_at, datetime)
+            assert item.longitude == 5.48124495540772 and isinstance(
+                item.longitude, float
+            )
+            assert item.latitude == 51.441680658515224 and isinstance(
+                item.latitude, float
+            )
 
 
 @pytest.mark.asyncio
@@ -140,6 +186,23 @@ async def test_car_charging_parking_types(aresponses: ResponsesMockServer) -> No
         client = ODPEindhoven(session=session)
         locations: list[ParkingSpot] = await client.locations(parking_type=6, limit=1)
         for item in locations:
-            assert item.spot_id == "9318b1236bce0c404dcf8bcbac22bdc72b3308ef"
-            assert item.street == "Professor Dr Dorgelolaan"
-            assert item.parking_type == "Parkeerplaats Electrisch opladen"
+            assert (
+                item.spot_id == "9318b1236bce0c404dcf8bcbac22bdc72b3308ef"
+                and isinstance(item.spot_id, str)
+            )
+            assert item.street == "Professor Dr Dorgelolaan" and isinstance(
+                item.street, str
+            )
+            assert (
+                item.parking_type == "Parkeerplaats Electrisch opladen"
+                and isinstance(item.parking_type, str)
+            )
+            assert item.updated_at == datetime(
+                2022, 9, 1, 21, 45, 3, 599000
+            ) and isinstance(item.updated_at, datetime)
+            assert item.longitude == 5.484090179656346 and isinstance(
+                item.longitude, float
+            )
+            assert item.latitude == 51.44487067822449 and isinstance(
+                item.latitude, float
+            )


### PR DESCRIPTION
For unknown reasons, the datetime timestamp of the Eindhoven API has been changed, through this PR the package is back in line with the data it gets.

fixes #99 